### PR TITLE
Adds txt files as data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude_also = [
 exclude = ["tests", "results"]
 
 [tool.setuptools.package-data]
-"*" = ["*.json"]
+"*" = ["*.json", "*.txt"]
 
 [tool.ruff]
 


### PR DESCRIPTION
This commit ensures that the_ugly_duckling.txt file is present when installing mteb[speedtask]. Avoids running into a `FileNotFoundError` when trying to run speed tasks.


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 